### PR TITLE
fix: quill hooks peer dependency

### DIFF
--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -9,5 +9,8 @@
     "type": "git",
     "url": "https://github.com/rpidanny/quill.git",
     "directory": "packages/hooks"
+  },
+  "peerDependencies": {
+    "@rpidanny/quill": "^1.5.0"
   }
 }

--- a/packages/hooks/project.json
+++ b/packages/hooks/project.json
@@ -11,7 +11,8 @@
         "outputPath": "dist/packages/hooks",
         "main": "packages/hooks/src/index.ts",
         "tsConfig": "packages/hooks/tsconfig.lib.json",
-        "assets": ["packages/hooks/*.md"]
+        "assets": ["packages/hooks/*.md"],
+        "buildableProjectDepsInPackageJsonType": "peerDependencies"
       }
     },
     "publish": {


### PR DESCRIPTION
# Your checklist for this pull request

❗ Please review the guidelines for contributing to this repository.

- [x] Make sure you are requesting to pull a improvement/feature/bugfix branch.
- [x] Make sure your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) convention of: `<type>(optional scope): <description>`.
- [x] Make sure you have added / updated any documentation of the components affected by this PR.

## Description

Fix quill hooks peer dependency so that quill is a peer dependency of hooks with loose versioning.

❤️ Thank you!
